### PR TITLE
stepwise modelling, issue #13

### DIFF
--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -21,6 +21,7 @@ from tfbpmodeling.lasso_modeling import (
     stratification_classification,
 )
 from tfbpmodeling.SigmoidModel import SigmoidModel
+from tfbpmodeling.loop_modeling import bootstrap_stratified_cv_loop
 
 logger = logging.getLogger("main")
 
@@ -216,16 +217,30 @@ def perturbation_binding_modeling(args):
     logger.info(
         f"Running bootstrap LassoCV on all data with {args.n_bootstraps} bootstraps"
     )
-    all_data_results = bootstrap_stratified_cv_modeling(
-        bootstrapped_data_all,
-        input_data.predictors_df[input_data.perturbed_tf],
-        estimator=estimator,
-        use_sample_weight_in_cv=args.use_weights_in_cv,
-        ci_percentiles=[float(args.all_data_ci_level)],
-        bin_by_binding_only=args.bin_by_binding_only,
-        bins=args.bins,
-    )
-
+    if args.iterative_dropout:
+        logger.info("Using iterative dropout modeling for all data results.")
+        all_data_results = bootstrap_stratified_cv_loop(
+            bootstrapped_data=bootstrapped_data_all,
+            perturbed_tf_series=input_data.predictors_df[input_data.perturbed_tf],
+            estimator=estimator,
+            ci_percentile=float(args.all_data_ci_level),
+            stabilization_ci_start=args.stabilization_ci_start,
+            use_sample_weight_in_cv=args.use_weights_in_cv,
+            bin_by_binding_only=args.bin_by_binding_only,
+            bins=args.bins,
+            output_dir=output_subdir
+        )
+    else:
+        logger.info("Using standard bootstrap modeling for all data results.")
+        all_data_results = bootstrap_stratified_cv_modeling(
+            bootstrapped_data=bootstrapped_data_all,
+            perturbed_tf_series=input_data.predictors_df[input_data.perturbed_tf],
+            estimator=estimator,
+            use_sample_weight_in_cv=args.use_weights_in_cv,
+            ci_percentiles=[float(args.all_data_ci_level)],
+            bin_by_binding_only=args.bin_by_binding_only,
+            bins=args.bins,
+        )
     # create the all data object output subdir
     all_data_output = os.path.join(output_subdir, "all_data_result_object")
     os.makedirs(all_data_output, exist_ok=True)
@@ -910,6 +925,20 @@ def main() -> None:
             "green_median"
         ),
     )
+
+    parameters_group.add_argument(
+        "--iterative_dropout",
+        action="store_true",
+        help="Enable iterative variable dropout based on confidence intervals.",
+    )
+
+    parameters_group.add_argument(
+        "--stabilization_ci_start",
+        type=float,
+        default=50.0,
+        help="Starting confidence interval for iterative dropout stabilization (default: 50.0).",
+    )
+
 
     # Output arguments
     output_group = lasso_parser.add_argument_group("Output")

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -20,8 +20,8 @@ from tfbpmodeling.lasso_modeling import (
     evaluate_interactor_significance,
     stratification_classification,
 )
-from tfbpmodeling.SigmoidModel import SigmoidModel
 from tfbpmodeling.loop_modeling import bootstrap_stratified_cv_loop
+from tfbpmodeling.SigmoidModel import SigmoidModel
 
 logger = logging.getLogger("main")
 
@@ -228,7 +228,7 @@ def perturbation_binding_modeling(args):
             use_sample_weight_in_cv=args.use_weights_in_cv,
             bin_by_binding_only=args.bin_by_binding_only,
             bins=args.bins,
-            output_dir=output_subdir
+            output_dir=output_subdir,
         )
     else:
         logger.info("Using standard bootstrap modeling for all data results.")
@@ -936,9 +936,8 @@ def main() -> None:
         "--stabilization_ci_start",
         type=float,
         default=50.0,
-        help="Starting confidence interval for iterative dropout stabilization (default: 50.0).",
+        help="Starting confidence interval for iterative dropout stabilization",
     )
-
 
     # Output arguments
     output_group = lasso_parser.add_argument_group("Output")

--- a/tfbpmodeling/loop_modeling.py
+++ b/tfbpmodeling/loop_modeling.py
@@ -69,7 +69,19 @@ def bootstrap_stratified_cv_loop(
 
         for index, (y_resampled, x_resampled, sample_weight) in islice(enumerate(bootstrapped_data), num_samples_for_stabilization):
             logger.debug(f"Bootstrap iteration index: {index}")
-
+        # Set the random state for StratifiedKFold to the current index
+        skf.random_state = i
+         
+         # the random_state for the estimator is used to choose among equally good
+        # variables. I'm not sure how much this affects results -- we are making
+        # a distribution of coefficients rather than letting sklearn choose a
+        # model for us -- but it is, similar to StratifiedKFold above, randomized
+        # but reproducible by setting random_state to the bootstrap iteration
+        try:
+            estimator.random_state = i
+        except AttributeError:
+            logger.warning("Estimator does not have a random_state attribute.")
+            pass
             classes = stratification_classification(
                 perturbed_tf_series.loc[y_resampled.index].squeeze(),
                 y_resampled.squeeze(),

--- a/tfbpmodeling/loop_modeling.py
+++ b/tfbpmodeling/loop_modeling.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LassoCV
+from sklearn.base import BaseEstimator, clone
+from sklearn.model_selection import StratifiedKFold
+from scipy.stats import rankdata
+import logging
+from itertools import islice
+import os
+
+# Import necessary classes and functions
+from tfbpmodeling.lasso_modeling import (
+    BootstrappedModelingInputData,
+    stratification_classification,
+    stratified_cv_modeling,
+    BootstrapModelResults,
+    bootstrap_stratified_cv_modeling
+)
+
+logger = logging.getLogger(__name__)
+
+def bootstrap_stratified_cv_loop(
+    bootstrapped_data: BootstrappedModelingInputData,
+    perturbed_tf_series: pd.Series,
+    estimator: BaseEstimator = LassoCV(
+        fit_intercept=True,
+        max_iter=10000,
+        selection="random",
+        random_state=42,
+        n_jobs=4,
+    ),
+    ci_percentile: float = 98.0,  # Final confidence interval
+    use_sample_weight_in_cv: bool = False,
+    stabilization_ci_start: float = 50.0,  # Starting CI for stabilization
+    num_samples_for_stabilization: int = 500,
+    output_dir: str = "",
+    **kwargs,
+) -> BootstrapModelResults:
+    """
+    Perform bootstrapped stratified CV modeling with iterative variable dropping
+    based on confidence intervals, and return results at the final confidence interval.
+
+    :param bootstrapped_data: Bootstrapped samples of predictors and response data.
+    :param perturbed_tf_series: Series of TF binding values for stratification.
+    :param estimator: scikit-learn estimator. Default is LassoCV.
+    :param ci_percentile: Final confidence interval for results (e.g., 99.0).
+    :param use_sample_weight_in_cv: Whether to use sample weights in CV.
+    :param stabilization_ci_start: Starting confidence interval for stabilization (e.g., 50.0).
+    :param stabilization_ci_step: Step size for increasing CI during stabilization.
+    :param kwargs: Additional arguments for stratification or modeling.
+
+    :return: A BootstrapModelResults object containing aggregated results.
+    """
+    current_ci = stabilization_ci_start
+    previous_num_variables = None
+    stabilized_variables = None
+
+    logger.info(f"Starting iterative variable dropping with CI={current_ci}")
+    i = 0
+    while True:
+        # Perform bootstrapped modeling at the current CI
+        bootstrap_coefs = []
+        alpha_list = []
+
+        for index, (y_resampled, x_resampled, sample_weight) in islice(enumerate(bootstrapped_data), num_samples_for_stabilization):
+            logger.debug(f"Bootstrap iteration index: {index}")
+
+            classes = stratification_classification(
+                perturbed_tf_series.loc[y_resampled.index].squeeze(),
+                y_resampled.squeeze(),
+                bin_by_binding_only=kwargs.get("bin_by_binding_only", False),
+                bins=kwargs.get("bins", [0, 8, 64, 512, np.inf]),
+            )
+
+            model_i = stratified_cv_modeling(
+                y_resampled,
+                x_resampled,
+                classes=classes,
+                estimator=estimator,
+                skf=StratifiedKFold(n_splits=4, shuffle=True, random_state=index),
+            )
+
+            alpha_list.append(model_i.alpha_)
+            bootstrap_coefs.append(model_i.coef_)
+
+        # Aggregate coefficients
+        bootstrap_coefs_df = pd.DataFrame(bootstrap_coefs, columns=bootstrapped_data.model_df.columns)
+
+        # Compute confidence intervals
+        ci_dict = {
+            colname: (
+                np.percentile(bootstrap_coefs_df[colname], (100 - current_ci) / 2),
+                np.percentile(bootstrap_coefs_df[colname], 100 - (100 - current_ci) / 2),
+            )
+            for colname in bootstrap_coefs_df.columns
+        }
+
+        # Select variables within the confidence interval
+        selected_variables = [
+            colname
+            for colname, (lower, upper) in ci_dict.items()
+            if lower > 0 or upper < 0
+        ]
+
+        logger.info(f"CI={current_ci}: Selected {len(selected_variables)} variables")
+        output_path = os.path.join(output_dir, f"selected_variables_ci_{i}.txt")
+        with open(output_path, "w") as f:
+            for var in selected_variables:
+                f.write(f"{var}\n")
+                
+        # Check for stabilization
+        if previous_num_variables is not None and len(selected_variables) == previous_num_variables:
+            stabilized_variables = selected_variables
+            logger.info(f"Stabilization achieved with {len(stabilized_variables)} variables")
+            break
+
+        previous_num_variables = len(selected_variables)
+
+        # Update the bootstrapped data to include only the selected variables
+        bootstrapped_data.model_df = bootstrapped_data.model_df[selected_variables]
+        i += 1
+
+    # Perform final modeling at the original confidence interval
+    logger.info(f"Performing final modeling at CI={ci_percentile}")
+    final_results = bootstrap_stratified_cv_modeling(
+        bootstrapped_data=bootstrapped_data,
+        perturbed_tf_series=perturbed_tf_series,
+        estimator=estimator,
+        ci_percentiles=[ci_percentile],
+        use_sample_weight_in_cv=use_sample_weight_in_cv,
+        **kwargs,
+    )
+
+    return final_results          

--- a/tfbpmodeling/loop_modeling.py
+++ b/tfbpmodeling/loop_modeling.py
@@ -54,7 +54,12 @@ def bootstrap_stratified_cv_loop(
     current_ci = stabilization_ci_start
     previous_num_variables = None
     stabilized_variables = None
-
+    # shuffle = True means that the partitioning is random.
+    # NOTE: In each iteration, the random state is updated to the current
+    # bootstrap iteration index. This ensures that the randomization is
+    # reproducible across different runs of the function, while still allowing
+    # for variability in how each bootstrap sample is partitioned into train/test
+    skf = StratifiedKFold(n_splits=4, shuffle=True, random_state=42)
     logger.info(f"Starting iterative variable dropping with CI={current_ci}")
     i = 0
     while True:

--- a/tfbpmodeling/tests/test_loop_modelling.py
+++ b/tfbpmodeling/tests/test_loop_modelling.py
@@ -1,11 +1,7 @@
-import json
-import os
-import tempfile
-from typing import Any
-
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.linear_model import LassoCV
 
 from tfbpmodeling.lasso_modeling import (
     BootstrapModelResults,
@@ -13,7 +9,7 @@ from tfbpmodeling.lasso_modeling import (
     ModelingInputData,
 )
 from tfbpmodeling.loop_modeling import bootstrap_stratified_cv_loop
-from sklearn.linear_model import LassoCV, LinearRegression
+
 
 @pytest.fixture
 def sample_data():
@@ -130,6 +126,7 @@ def bootstrapped_random_sample_data(random_sample_data):
         n_bootstraps=100,
     )
 
+
 def test_bootstrap_stratified_cv_loop(
     random_sample_data,
     bootstrapped_random_sample_data,
@@ -139,15 +136,15 @@ def test_bootstrap_stratified_cv_loop(
     perturbed_tf_series = random_sample_data.predictors_df[
         random_sample_data.perturbed_tf
     ]
-    estimator = LassoCV()   
+    estimator = LassoCV()
     results = bootstrap_stratified_cv_loop(
         bootstrapped_data=bootstrapped_random_sample_data,
         perturbed_tf_series=perturbed_tf_series,
         estimator=estimator,
         ci_percentile=20.0,
-        stabilization_ci_start = 10.0, 
+        stabilization_ci_start=10.0,
         num_samples_for_stabilization=10,
-        output_dir=str(tmp_path)
+        output_dir=str(tmp_path),
     )
 
     # Check result object

--- a/tfbpmodeling/tests/test_loop_modelling.py
+++ b/tfbpmodeling/tests/test_loop_modelling.py
@@ -1,0 +1,163 @@
+import json
+import os
+import tempfile
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tfbpmodeling.lasso_modeling import (
+    BootstrapModelResults,
+    BootstrappedModelingInputData,
+    ModelingInputData,
+)
+from tfbpmodeling.loop_modeling import bootstrap_stratified_cv_loop
+from sklearn.linear_model import LassoCV, LinearRegression
+
+@pytest.fixture
+def sample_data():
+    """Fixture to create sample response and predictor data."""
+    response_data = pd.DataFrame(
+        {
+            "target_symbol": ["gene1", "gene2", "gene3", "gene4", "gene5"],
+            "expression": [2.5, 3.2, 1.8, 4.1, 2.9],
+        }
+    )
+
+    predictors_data = pd.DataFrame(
+        {
+            "target_symbol": ["gene1", "gene2", "gene3", "gene4", "gene5"],
+            "TF1": [0.5, 0.8, 0.2, 0.9, 0.7],
+            "TF2": [1.2, 1.5, 1.1, 1.7, 1.3],
+            "TF3": [0.3, 0.4, 0.2, 0.5, 0.3],
+        }
+    )
+
+    return response_data, predictors_data
+
+
+@pytest.fixture
+def bootstrapped_sample_data(sample_data):
+    response_df, predictors_df = sample_data
+    input_data = ModelingInputData(response_df, predictors_df, perturbed_tf="TF1")
+    model_df = input_data.get_modeling_data(formula="TF1 + TF1:TF2 + TF1:TF3 - 1")
+
+    return BootstrappedModelingInputData(
+        input_data.response_df, model_df, n_bootstraps=5
+    )
+
+
+@pytest.fixture
+def modeling_input_instance(sample_data):
+    """Creates an instance of ModelingInputData with sample data."""
+    response_df, predictors_df = sample_data
+    return ModelingInputData(response_df, predictors_df, perturbed_tf="TF1")
+
+
+@pytest.fixture
+def random_sample_data():
+    """Generates synthetic response and predictor data with consistent indexing,
+    ensuring the response is derived from a subset of predictors."""
+    np.random.seed(42)  # Ensure reproducibility
+    total_features = 100
+
+    # Feature column names: gene1, gene2, ..., gene100
+    feature_col = [f"gene{i+1}" for i in range(total_features)]
+
+    # Select predictor columns: gene5 to gene14
+    predictor_columns = feature_col[4:14]  # (gene5 to gene14)
+
+    # Number of samples
+    n_samples = 100
+
+    # Generate predictors DataFrame
+    predictors_df = pd.DataFrame(
+        np.random.randn(n_samples, len(predictor_columns)),
+        columns=predictor_columns,
+        index=[f"gene{i+1}" for i in range(n_samples)],
+    ).reset_index(names="target_symbol")
+
+    # Generate a response variable based on gene5, gene5:gene7, and gene5:gene10
+    response_values = (
+        1.5 * predictors_df["gene5"]  # Main effect of gene5
+        + 0.8
+        * (predictors_df["gene5"] * predictors_df["gene7"])  # Interaction: gene5:gene7
+        + 0.6
+        * (
+            predictors_df["gene5"] * predictors_df["gene10"]
+        )  # Interaction: gene5:gene10
+        + np.random.randn(n_samples) * 0.5  # Add noise
+    )
+
+    # Create response DataFrame
+    response_df = pd.DataFrame(
+        {"response": response_values, "target_symbol": predictors_df.target_symbol}
+    )
+
+    return ModelingInputData(
+        response_df=response_df,
+        predictors_df=predictors_df,
+        perturbed_tf="gene5",
+        feature_col="target_symbol",
+        feature_blacklist=["gene1", "gene2"],
+        top_n=20,
+    )
+
+
+@pytest.fixture
+def bootstrapped_random_sample_data(random_sample_data):
+    """Generates a BootstrappedModelingInputData instance with random sample data."""
+
+    random_sample_data.top_n_masked = False
+
+    # Extract predictor variables and drop the perturbed TF
+    predictor_variables = random_sample_data.predictors_df.columns.drop(
+        random_sample_data.perturbed_tf
+    )
+
+    # Create interaction
+    interaction_terms = [
+        f"{random_sample_data.perturbed_tf}:{var}" for var in predictor_variables
+    ]
+
+    # Construct the formula as a single expression (no intercept)
+    formula = f"{random_sample_data.perturbed_tf} + {' + '.join(interaction_terms)} - 1"
+
+    return BootstrappedModelingInputData(
+        random_sample_data.response_df,
+        random_sample_data.get_modeling_data(formula=formula),
+        n_bootstraps=100,
+    )
+
+def test_bootstrap_stratified_cv_loop(
+    random_sample_data,
+    bootstrapped_random_sample_data,
+    tmp_path,
+):
+    """Test that bootstrap_stratified_cv_loop runs and saves files to tmp_path."""
+    perturbed_tf_series = random_sample_data.predictors_df[
+        random_sample_data.perturbed_tf
+    ]
+    estimator = LassoCV()   
+    results = bootstrap_stratified_cv_loop(
+        bootstrapped_data=bootstrapped_random_sample_data,
+        perturbed_tf_series=perturbed_tf_series,
+        estimator=estimator,
+        ci_percentile=20.0,
+        stabilization_ci_start = 10.0, 
+        num_samples_for_stabilization=10,
+        output_dir=str(tmp_path)
+    )
+
+    # Check result object
+    assert isinstance(results, BootstrapModelResults)
+
+    # Check that a file was saved in tmp_path
+    saved_files = list(tmp_path.glob("selected_variables_ci_*.txt"))
+    assert len(saved_files) >= 1
+
+    # Optional: check that saved file contains valid variable names
+    with saved_files[-1].open("r") as f:
+        contents = f.read().strip()
+        assert len(contents) > 0


### PR DESCRIPTION
To incorporate the step-wise feature elimination, add the flags:

        --iterative_dropout \
        --stabilization_ci_start=$ci
        
when calling perturbation_binding_modeling

if --iterative_dropout is enabled, it does a pass of feature dropout before calling the bootstrap_stratified_cv_modeling at the final confidence interval. 