### PR TITLE
Set random state on bootstraps; Remove unweighted bootstrap option

### DIFF
--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -1123,18 +1123,6 @@ def main() -> None:
             "the bootstrap results."
         ),
     )
-    sigmoid_step3_parameters_group = sigmoid_step3_parser.add_argument_group(
-        "Parameters"
-    )
-    sigmoid_step3_parameters_group.add_argument(
-        "--top_n",
-        type=int,
-        default=600,
-        help=(
-            "Number of features to retain in the second round of modeling. "
-            "Default is 600"
-        ),
-    )
 
     sigmoid_step3_model_binning_group = sigmoid_step3_parser.add_argument_group(
         "Binning Options"

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -785,6 +785,16 @@ def common_modeling_input_arguments(
         ),
     )
     parser.add_argument(
+        "--center_scale",
+        action="store_true",
+        help=(
+            "Set this to center and scale the model matrix. Note that "
+            "omitting `drop_intercept` will mean that the model matrix will be scaled "
+            "only, not centered. Set `--drop_intercept` and `--center_scale` to both "
+            "center and scale the model matrix. Default is False."
+        ),
+    )
+    parser.add_argument(
         "--top_n",
         type=int,
         default=top_n_default,

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -92,37 +92,6 @@ def linear_perturbation_binding_modeling(args):
         os.makedirs(output_subdir, exist_ok=True)
         logger.info(f"Output subdirectory created at {output_subdir}")
 
-    try:
-        all_data_bootstrap_indicies = (
-            BootstrappedModelingInputData.load_indices(args.all_data_bootstrap_indicies)
-            if args.all_data_bootstrap_indicies
-            else None
-        )
-    except FileNotFoundError:
-        logger.error(
-            f"Bootstrap indices file {args.all_data_bootstrap_indicies} not found."
-        )
-        raise
-
-    try:
-        topn_data_bootstrap_indicies = (
-            BootstrappedModelingInputData.load_indices(
-                args.topn_data_bootstrap_indicies
-            )
-            if args.topn_data_bootstrap_indicies
-            else None
-        )
-    except FileNotFoundError:
-        logger.error(
-            f"Bootstrap indices file {args.topn_data_bootstrap_indicies} not found."
-        )
-        raise
-
-    # if the bootstrap indicies are not provided, then set the number of bootstraps
-    # to the value passed in via the command line
-    all_data_n_bootstraps = None if all_data_bootstrap_indicies else args.n_bootstraps
-    topn_data_n_bootstraps = None if topn_data_bootstrap_indicies else args.n_bootstraps
-
     # instantiate a estimator
     # NOTE: fit_intercept is set to `true`. This means the intercept WILL BE fit
     # DO NOT add a constant vector to the predictors.
@@ -204,24 +173,10 @@ def linear_perturbation_binding_modeling(args):
             drop_intercept=True,
             center_scale=args.center_scale,
         ),
-        n_bootstraps=all_data_n_bootstraps,
-        bootstrap_indices=all_data_bootstrap_indicies,
+        n_bootstraps=args.n_bootstraps,
+        normalize_sample_weights=args.normalize_sample_weights,
+        random_state=args.random_state,
     )
-
-    if not all_data_bootstrap_indicies:
-        all_data_indicies_output_file = os.path.join(
-            output_subdir, "all_data_bootstrap_indices.json"
-        )
-        logger.info(
-            "Saving the bootstrap indices for the all "
-            f"data model to {all_data_indicies_output_file}"
-        )
-        bootstrapped_data_all.save_indices(all_data_indicies_output_file)
-    else:
-        logger.info(
-            "Using the provided bootstrap indices for the all data model from "
-            f"{args.all_data_bootstrap_indicies}"
-        )
 
     logger.info(
         f"Running bootstrap LassoCV on all data with {args.n_bootstraps} bootstraps"
@@ -305,26 +260,12 @@ def linear_perturbation_binding_modeling(args):
             drop_intercept=True,
             center_scale=args.center_scale,
         ),
-        n_bootstraps=topn_data_n_bootstraps,
-        bootstrap_indices=topn_data_bootstrap_indicies,
+        n_bootstraps=args.n_bootstraps,
+        normalize_sample_weights=args.normalize_sample_weights,
+        random_state=(
+            args.random_state + 10 if args.random_state else args.random_state
+        ),
     )
-
-    # If the bootstrap indicies are generated from the data, save them to a json file
-    # so that they can be reused in subsequent runs
-    if not topn_data_bootstrap_indicies:
-        topn_indicies_output_file = os.path.join(
-            output_subdir, "topn_bootstrap_indices.json"
-        )
-        logger.info(
-            "Saving the bootstrap indices for the topn data "
-            f"to {topn_indicies_output_file}"
-        )
-        bootstrapped_data_top_n.save_indices(topn_indicies_output_file)
-    else:
-        logger.info(
-            "Using the provided bootstrap indices for the topn data from "
-            f"{args.topn_data_bootstrap_indicies}"
-        )
 
     logger.debug(
         f"Running bootstrap LassoCV on topn data with {args.n_bootstraps} bootstraps"
@@ -556,15 +497,12 @@ def sigmoid_bootstrap_worker(
         center_scale=args.center_scale,
     )
 
-    bootstrap_indices = BootstrappedModelingInputData.load_indices(
-        args.bootstrap_indices_file
-    )
     bootstrap_data = BootstrappedModelingInputData(
         response_df=input_data.response_df,
         model_df=model_df,
-        n_bootstraps=None,
-        bootstrap_indices=bootstrap_indices,
+        n_bootstraps=args.n_bootstraps,
         normalize_sample_weights=args.normalize_sample_weights,
+        random_state=args.random_state,
     )
 
     _, _, sample_weights = bootstrap_data.get_bootstrap_sample(i)
@@ -825,6 +763,28 @@ def common_modeling_input_arguments(parser: argparse._ArgumentGroup) -> None:
             "from the analysis."
         ),
     )
+    parser.add_argument(
+        "--n_bootstraps",
+        type=int,
+        default=1000,
+        help="Number of bootstrap samples to generate for resampling. Default is 1000",
+    )
+    parser.add_argument(
+        "--random_state",
+        type=int,
+        default=None,
+        help="Set this to an integer to make the bootstrap sampling reproducible. "
+        "Default is None (no fixed seed) and each call will produce different "
+        "bootstrap indices. Note that if this is set, the `top_n` random_state will "
+        "be +10 in order to make the top_n indicies different from the `all_data` step",
+    )
+    parser.add_argument(
+        "--normalize_sample_weights",
+        action="store_true",
+        help=(
+            "Set this to normalize the sample weights to sum to 1. " "Default is False."
+        ),
+    )
 
 
 def common_modeling_feature_options(parser: argparse._ArgumentGroup) -> None:
@@ -945,30 +905,6 @@ def main() -> None:
 
     common_modeling_input_arguments(linear_input_group)
 
-    linear_input_group.add_argument(
-        "--all_data_bootstrap_indicies",
-        type=str,
-        default=None,
-        help=(
-            "Path to a JSON file containing the bootstrap indices for the all data "
-            "model. If provided, these indices will be used instead of generating "
-            "new ones. If not provided, new bootstrap indices will be generated "
-            "and saved."
-        ),
-    )
-
-    linear_input_group.add_argument(
-        "--topn_data_bootstrap_indicies",
-        type=str,
-        default=None,
-        help=(
-            "Path to a JSON file containing the bootstrap indices for the topn data "
-            "model. If provided, these indices will be used instead of generating "
-            "new ones. If not provided, new bootstrap indices will be generated "
-            "and saved."
-        ),
-    )
-
     linear_model_feature_options_group = linear_lasso_parser.add_argument_group(
         "Feature Options"
     )
@@ -990,13 +926,6 @@ def main() -> None:
             "Number of features to retain in the second round of modeling. "
             "Default is 600"
         ),
-    )
-
-    linear_parameters_group.add_argument(
-        "--n_bootstraps",
-        type=int,
-        default=1000,
-        help="Number of bootstrap samples to generate for resampling. Default is 1000",
     )
 
     linear_parameters_group.add_argument(
@@ -1103,16 +1032,6 @@ def main() -> None:
     common_modeling_input_arguments(sigmoid_input_group)
 
     sigmoid_input_group.add_argument(
-        "--bootstrap_indices_file",
-        type=str,
-        required=True,
-        help=(
-            "Path to a JSON file containing the bootstrap indices for the model. "
-            "These indices will be used for resampling."
-        ),
-    )
-
-    sigmoid_input_group.add_argument(
         "--bootstrap_idx",
         type=int,
         required=True,
@@ -1167,14 +1086,6 @@ def main() -> None:
             "maxcor=10, ftol=2.22e-9, gtol=1e-5, eps=1e-8, maxfun=15000, "
             "maxiter=15000, maxls=20, finite_diff_rel_step=None. "
             'Example: \'{"maxiter": 1000, "gtol": 1e-6}\''
-        ),
-    )
-
-    sigmoid_parameters_group.add_argument(
-        "--normalize_sample_weights",
-        action="store_true",
-        help=(
-            "Set this to normalize the sample weights to sum to 1. " "Default is False."
         ),
     )
 

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -189,7 +189,6 @@ def linear_perturbation_binding_modeling(args):
             estimator=estimator,
             ci_percentile=float(args.all_data_ci_level),
             stabilization_ci_start=args.stabilization_ci_start,
-            use_sample_weight_in_cv=args.use_weights_in_cv,
             bin_by_binding_only=args.bin_by_binding_only,
             bins=args.bins,
             output_dir=output_subdir,
@@ -200,7 +199,6 @@ def linear_perturbation_binding_modeling(args):
             bootstrapped_data=bootstrapped_data_all,
             perturbed_tf_series=input_data.predictors_df[input_data.perturbed_tf],
             estimator=estimator,
-            use_sample_weight_in_cv=args.use_weights_in_cv,
             ci_percentiles=[float(args.all_data_ci_level)],
             bin_by_binding_only=args.bin_by_binding_only,
             bins=args.bins,
@@ -274,7 +272,6 @@ def linear_perturbation_binding_modeling(args):
         bootstrapped_data_top_n,
         input_data.predictors_df[input_data.perturbed_tf],
         estimator=estimator,
-        use_sample_weight_in_cv=args.use_weights_in_cv,
         ci_percentiles=[float(args.topn_ci_level)],
     )
 
@@ -505,7 +502,7 @@ def sigmoid_bootstrap_worker(
         random_state=args.random_state,
     )
 
-    _, _, sample_weights = bootstrap_data.get_bootstrap_sample(i)
+    _, sample_weights = bootstrap_data.get_bootstrap_sample(i)
 
     classes = stratification_classification(
         input_data.predictors_df[input_data.perturbed_tf].squeeze(),
@@ -721,7 +718,9 @@ def common_modeling_binning_arguments(parser: argparse._ArgumentGroup) -> None:
     )
 
 
-def common_modeling_input_arguments(parser: argparse._ArgumentGroup) -> None:
+def common_modeling_input_arguments(
+    parser: argparse._ArgumentGroup, top_n_default: int | None = 600
+) -> None:
     """Add common input arguments for modeling commands."""
     parser.add_argument(
         "--response_file",
@@ -776,13 +775,22 @@ def common_modeling_input_arguments(parser: argparse._ArgumentGroup) -> None:
         help="Set this to an integer to make the bootstrap sampling reproducible. "
         "Default is None (no fixed seed) and each call will produce different "
         "bootstrap indices. Note that if this is set, the `top_n` random_state will "
-        "be +10 in order to make the top_n indicies different from the `all_data` step",
+        "be +10 in order to make the top_n indices different from the `all_data` step",
     )
     parser.add_argument(
         "--normalize_sample_weights",
         action="store_true",
         help=(
             "Set this to normalize the sample weights to sum to 1. " "Default is False."
+        ),
+    )
+    parser.add_argument(
+        "--top_n",
+        type=int,
+        default=top_n_default,
+        help=(
+            "Number of features to retain in the second round of modeling. "
+            f"Default is {top_n_default}"
         ),
     )
 
@@ -903,7 +911,7 @@ def main() -> None:
     # Input arguments
     linear_input_group = linear_lasso_parser.add_argument_group("Input")
 
-    common_modeling_input_arguments(linear_input_group)
+    common_modeling_input_arguments(linear_input_group, top_n_default=600)
 
     linear_model_feature_options_group = linear_lasso_parser.add_argument_group(
         "Feature Options"
@@ -917,16 +925,6 @@ def main() -> None:
     common_modeling_binning_arguments(linear_model_binning_group)
 
     linear_parameters_group = linear_lasso_parser.add_argument_group("Parameters")
-
-    linear_parameters_group.add_argument(
-        "--top_n",
-        type=int,
-        default=600,
-        help=(
-            "Number of features to retain in the second round of modeling. "
-            "Default is 600"
-        ),
-    )
 
     linear_parameters_group.add_argument(
         "--all_data_ci_level",
@@ -955,15 +953,6 @@ def main() -> None:
         help=(
             "This controls the maximum number of iterations LassoCV may "
             "use in order to fit"
-        ),
-    )
-
-    linear_parameters_group.add_argument(
-        "--use_weights_in_cv",
-        action="store_true",
-        help=(
-            "Enable sample weighting in cross-validation based on bootstrap "
-            "sample proportions."
         ),
     )
 
@@ -1029,7 +1018,7 @@ def main() -> None:
 
     sigmoid_input_group = sigmoid_parser.add_argument_group("Input")
 
-    common_modeling_input_arguments(sigmoid_input_group)
+    common_modeling_input_arguments(sigmoid_input_group, top_n_default=None)
 
     sigmoid_input_group.add_argument(
         "--bootstrap_idx",
@@ -1043,16 +1032,6 @@ def main() -> None:
 
     sigmoid_parameters_group = sigmoid_parser.add_argument_group("Parameters")
 
-    sigmoid_parameters_group.add_argument(
-        "--top_n",
-        type=int,
-        default=None,
-        help=(
-            "This is the number of features to use for second round modeling. "
-            "Defaults to `Non`, for the 'all_data' model. Set to eg 600 for top_n "
-            "modeling"
-        ),
-    )
     sigmoid_parameters_group.add_argument(
         "--ci_level",
         type=float,

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -93,8 +93,10 @@ def linear_perturbation_binding_modeling(args):
         logger.info(f"Output subdirectory created at {output_subdir}")
 
     # instantiate a estimator
-    # NOTE: fit_intercept is set to `true`. This means the intercept WILL BE fit
-    # DO NOT add a constant vector to the predictors.
+    # `fit_intercept` is set opposite of `center_scale`. If `center_scale` is `False`,
+    # the default, then `fit_intercept` is set to True and the estimator will fit the
+    # intercept. If `center_scale` is True, then the estimator will not fit the
+    # intercept, meaning it assumes the data is centered.
     estimator = LassoCV(
         fit_intercept=not args.center_scale,
         selection="random",

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -163,8 +163,7 @@ def linear_perturbation_binding_modeling(args):
         )
         all_data_formula += " + " + " + ".join(args.add_model_variables)
 
-    # log the formula
-    logger.info(f"All data formula for the full interactor model: {all_data_formula}")
+    logger.debug(f"All data formula: {all_data_formula}")
 
     # create the bootstrapped data.
     bootstrapped_data_all = BootstrappedModelingInputData(
@@ -246,7 +245,7 @@ def linear_perturbation_binding_modeling(args):
     # Create the formula for the topn modeling from the significant coefficients
     # NOTE: to remove the intercept, we need to add " -1 "
     topn_formula = f"{' + '.join(all_data_sig_coefs.keys())}"
-    logger.info(f"Topn formula: {topn_formula}")
+    logger.debug(f"Topn formula: {topn_formula}")
 
     # apply the top_n masking
     input_data.top_n_masked = True

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -490,7 +490,7 @@ def sigmoid_bootstrap_worker(
     model_df = input_data.get_modeling_data(
         formula,
         add_row_max=args.row_max,
-        drop_intercept=args.drop_intercept,
+        drop_intercept=True,
         center_scale=args.center_scale,
     )
 

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -96,7 +96,7 @@ def linear_perturbation_binding_modeling(args):
     # NOTE: fit_intercept is set to `true`. This means the intercept WILL BE fit
     # DO NOT add a constant vector to the predictors.
     estimator = LassoCV(
-        fit_intercept=True,
+        fit_intercept=not args.center_scale,
         selection="random",
         n_alphas=100,
         random_state=42,
@@ -490,7 +490,7 @@ def sigmoid_bootstrap_worker(
     model_df = input_data.get_modeling_data(
         formula,
         add_row_max=args.row_max,
-        drop_intercept=True,
+        drop_intercept=args.drop_intercept,
         center_scale=args.center_scale,
     )
 
@@ -788,10 +788,9 @@ def common_modeling_input_arguments(
         "--center_scale",
         action="store_true",
         help=(
-            "Set this to center and scale the model matrix. Note that "
-            "omitting `drop_intercept` will mean that the model matrix will be scaled "
-            "only, not centered. Set `--drop_intercept` and `--center_scale` to both "
-            "center and scale the model matrix. Default is False."
+            "Set this to center and scale the model matrix. Note that setting this "
+            "will set the `fit_intercept` parameter of the LassoCV estimator to "
+            "False."
         ),
     )
     parser.add_argument(
@@ -806,11 +805,6 @@ def common_modeling_input_arguments(
 
 
 def common_modeling_feature_options(parser: argparse._ArgumentGroup) -> None:
-    parser.add_argument(
-        "--drop_intercept",
-        action="store_true",
-        help="Drop the intercept from the model. Default is False",
-    )
     parser.add_argument(
         "--row_max",
         action="store_true",
@@ -1041,6 +1035,15 @@ def main() -> None:
     )
 
     sigmoid_parameters_group = sigmoid_parser.add_argument_group("Parameters")
+
+    sigmoid_parameters_group.add_argument(
+        "--drop_intercept",
+        action="store_true",
+        help=(
+            "If set, the model matrix will not include an intercept term. "
+            "Default is False, which means the model will include an intercept."
+        ),
+    )
 
     sigmoid_parameters_group.add_argument(
         "--ci_level",

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -449,9 +449,7 @@ class ModelingInputData:
                 scaled_values, index=design_matrix.index, columns=design_matrix.columns
             )
 
-        logger.info(
-            f"Design matrix columns: {design_matrix.columns}",
-        )
+        logger.info("Design matrix columns: %s", list(design_matrix.columns))
 
         return design_matrix
 

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -442,7 +442,7 @@ class ModelingInputData:
             raise
 
         if center_scale:
-            logger.info(f"Center matrix = `{drop_intercept}`). Scale matrix = `True`")
+            logger.info(f"Center matrix = `{drop_intercept}`. Scale matrix = `True`")
             scaler = StandardScaler(with_mean=drop_intercept)
             scaled_values = scaler.fit_transform(design_matrix)
             design_matrix = pd.DataFrame(

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -449,7 +449,7 @@ class ModelingInputData:
                 scaled_values, index=design_matrix.index, columns=design_matrix.columns
             )
 
-        logger.info("Design matrix columns: %s", list(design_matrix.columns))
+        logger.info(f"Design matrix columns: {list(design_matrix.columns)}")
 
         return design_matrix
 
@@ -556,6 +556,11 @@ class BootstrappedModelingInputData:
         # set the random number generator attribute
         self.random_state = random_state
         self._rng = check_random_state(self.random_state)
+        logger.info(
+            f"Using random state: {self.random_state}"
+            if self.random_state is not None
+            else "No explicit random state set."
+        )
 
         # Initialize attributes
         self._bootstrap_indices: list[np.ndarray] = []

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -1391,7 +1391,6 @@ def bootstrap_stratified_cv_modeling(
             logger.warning("Estimator does not have a random_state attribute.")
             pass
 
-        logger.info("Performing CV by sample weights")
         classes = stratification_classification(
             perturbed_tf_series.loc[bootstrapped_data.response_df.index].squeeze(),
             bootstrapped_data.response_df.squeeze(),

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -15,7 +15,7 @@ from sklearn.base import BaseEstimator, clone
 from sklearn.linear_model import LassoCV, LinearRegression
 from sklearn.model_selection import StratifiedKFold
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils import resample
+from sklearn.utils import check_random_state, resample
 
 from tfbpmodeling.stratification_classification import (
     stratification_classification,
@@ -520,9 +520,9 @@ class BootstrappedModelingInputData:
         self,
         response_df: pd.DataFrame,
         model_df: pd.DataFrame,
-        n_bootstraps: int | None = None,
-        bootstrap_indices: list[np.ndarray] | None = None,
+        n_bootstraps: int,
         normalize_sample_weights: bool = True,
+        random_state: int | None = None,
     ) -> None:
         """
         Initialize bootstrapped modeling input.
@@ -532,54 +532,125 @@ class BootstrappedModelingInputData:
         :param response_df: Response variable.
         :param model_df: Predictor matrix.
         :param n_bootstraps: Number of bootstrap replicates to generate.
-        :param bootstrap_indices: Precomputed bootstrap sample indices.
+        :param random_state: Random state for reproducibility. Can be an integer or a
+            numpy RandomState object, or None. If None (default), then a random
+            random state is chosen.
 
-        :raises ValueError: if the inputs are invalid.
+        :raises ValueError: if the response_df and model_df do not have the same index
+            or if arguments are not correct datatype.
 
         """
-        if not isinstance(response_df, pd.DataFrame):
-            raise TypeError("response_df must be a DataFrame.")
-        if not isinstance(model_df, pd.DataFrame):
-            raise TypeError("model_df must be a DataFrame.")
-        if not response_df.index.equals(model_df.index):
-            raise ValueError("response_df and model_df must have the same index order.")
-        if n_bootstraps and bootstrap_indices:
-            raise ValueError(
-                "Either `n_bootstraps` or `bootstrap_indices` "
-                "must be provided, not both."
-            )
 
         self.response_df: pd.DataFrame = response_df
         self.model_df: pd.DataFrame = model_df
+        if not response_df.index.equals(model_df.index):
+            raise IndexError("response_df and model_df must have the same index order.")
         self.normalize_sample_weights = normalize_sample_weights
 
         # If bootstrap_indices is provided, set n_bootstraps based on its length
-        if bootstrap_indices is not None:
-            if not isinstance(bootstrap_indices, list) or not all(
-                isinstance(indices, np.ndarray) for indices in bootstrap_indices
-            ):
-                raise ValueError("bootstrap_indices must be a list of numpy arrays.")
-            if len(bootstrap_indices) == 0:
-                raise ValueError("bootstrap_indices must not be empty.")
-            self.n_bootstraps: int = len(bootstrap_indices)
-        else:
-            if n_bootstraps is None:
-                raise ValueError(
-                    "Either `n_bootstraps` or `bootstrap_indices` must be provided."
-                )
-            if not isinstance(n_bootstraps, int) or n_bootstraps <= 0:
-                raise ValueError("n_bootstraps must be a positive integer.")
-            self.n_bootstraps = n_bootstraps
+        self.n_bootstraps = n_bootstraps
+
+        # set the random number generator attribute
+        self.random_state = random_state
+        self._rng = check_random_state(self.random_state)
 
         # Initialize attributes
         self._bootstrap_indices: list[np.ndarray] = []
         self._sample_weights: dict[int, np.ndarray] = {}
 
-        # Validate or generate bootstrap indices
-        if bootstrap_indices is not None:
-            self.bootstrap_indices = bootstrap_indices
-        else:
-            self._generate_bootstrap_indices()
+        self._generate_bootstrap_indices()
+
+    @property
+    def response_df(self) -> pd.DataFrame:
+        """
+        Get the response DataFrame.
+
+        :return: The response DataFrame.
+
+        """
+        return self._response_df
+
+    @response_df.setter
+    def response_df(self, value: pd.DataFrame) -> None:
+        """
+        Set the response DataFrame and validate it.
+
+        :param value: The response DataFrame to set.
+        :raises TypeError: if the input is not a dataframe
+        :raises IndexError: if the input dataframe has an empty index.
+
+        """
+        if not isinstance(value, pd.DataFrame):
+            raise TypeError("response_df must be a DataFrame.")
+        if value.index.empty:
+            raise IndexError("response_df must have a non-empty index.")
+        self._response_df = value
+
+    @property
+    def model_df(self) -> pd.DataFrame:
+        """
+        Get the model DataFrame.
+
+        :return: The model DataFrame.
+
+        """
+        return self._model_df
+
+    @model_df.setter
+    def model_df(self, value: pd.DataFrame) -> None:
+        """
+        Set the model DataFrame and validate it.
+
+        :param value: The model DataFrame to set.
+        :raises TypeError: if the input is not a dataframe
+        :raises IndexError: if the input dataframe has an empty index.
+
+        """
+        if not isinstance(value, pd.DataFrame):
+            raise TypeError("model_df must be a DataFrame.")
+        if value.index.empty:
+            raise IndexError("model_df must have a non-empty index.")
+        self._model_df = value
+
+    @property
+    def random_state(self) -> int | None:
+        """
+        An integer used to set the random state when generating the bootstrap samples.
+
+        Set this explicitly for reproducibility
+
+        """
+        return self._random_state
+
+    @random_state.setter
+    def random_state(self, value: int | None) -> None:
+        if not isinstance(value, (int, type(None))):
+            raise TypeError("random state must be an integer or None")
+        self._random_state = value
+
+    @property
+    def n_bootstraps(self) -> int:
+        """
+        Get the number of bootstrap samples.
+
+        :return: The number of bootstrap samples.
+
+        """
+        return self._n_bootstraps
+
+    @n_bootstraps.setter
+    def n_bootstraps(self, value: int) -> None:
+        """
+        Set the number of bootstrap samples.
+
+        :param value: The number of bootstrap samples to generate.
+        :raises TypeError: If the value is not a positive integer.
+
+        """
+        if not isinstance(value, int) or value <= 0:
+            raise TypeError("n_bootstraps must be a positive integer.")
+        logger.info(f"Number of bootstrap samples set to: {value}")
+        self._n_bootstraps = value
 
     @property
     def bootstrap_indices(self) -> list[np.ndarray]:
@@ -599,12 +670,12 @@ class BootstrappedModelingInputData:
         if not isinstance(value, list) or not all(
             isinstance(indices, np.ndarray) for indices in value
         ):
-            raise ValueError("bootstrap_indices must be a list of numpy arrays.")
+            raise TypeError("bootstrap_indices must be a list of numpy arrays.")
 
         valid_indices = set(self.response_df.index)
         for i, indices in enumerate(value):
             if not set(indices).issubset(valid_indices):
-                raise ValueError(
+                raise IndexError(
                     f"Bootstrap sample {i} contains invalid "
                     "indices not found in response_df."
                 )
@@ -628,11 +699,11 @@ class BootstrappedModelingInputData:
         Set the normalization status for sample weights.
 
         :param value: Boolean indicating whether to normalize sample weights.
-        :raises ValueError: If the input is not a boolean.
+        :raises TypeError: If the input is not a boolean.
 
         """
         if not isinstance(value, bool):
-            raise ValueError("normalize_sample_weights must be a boolean.")
+            raise TypeError("normalize_sample_weights must be a boolean.")
         logger.info(f"Sample weights normalization set to: {value}")
         self._normalize_sample_weights = value
 
@@ -652,13 +723,13 @@ class BootstrappedModelingInputData:
         Set the sample weights directly.
 
         :param value: Dictionary mapping index to numpy arrays of weights.
-        :raises ValueError: If the input is not a dictionary of int to ndarray.
+        :raises TypeError: If the input is not a dictionary of int to ndarray.
 
         """
         if not isinstance(value, dict) or not all(
             isinstance(k, int) and isinstance(v, np.ndarray) for k, v in value.items()
         ):
-            raise ValueError("sample_weights must be a dictionary of numpy arrays.")
+            raise TypeError("sample_weights must be a dictionary of numpy arrays.")
         self._sample_weights = value
 
     def _generate_bootstrap_indices(self) -> None:
@@ -666,7 +737,8 @@ class BootstrappedModelingInputData:
         y_indices: np.ndarray = self.response_df.index.to_numpy()
 
         self._bootstrap_indices = [
-            resample(y_indices, replace=True) for _ in range(self.n_bootstraps)
+            resample(y_indices, replace=True, random_state=self._rng)
+            for _ in range(self.n_bootstraps)
         ]
         self._compute_sample_weights()
 
@@ -766,24 +838,6 @@ class BootstrappedModelingInputData:
         with open(filename, "w") as f:
             json.dump(data, f)
 
-    @classmethod
-    def load_indices(cls, filename: str) -> list[np.ndarray]:
-        """
-        Loads bootstrap indices from a JSON file.
-
-        :param filename: Path to the JSON file containing bootstrap indices. This likely
-            was created by `save_indices()` method.
-        :return: A list of numpy arrays representing the bootstrap indices.
-        :raises FileNotFoundError: If the file does not exist.
-
-        """
-        if not os.path.exists(filename):
-            raise FileNotFoundError(f"File '{filename}' does not exist.")
-        with open(filename) as f:
-            data = json.load(f)
-
-        return [np.array(indices) for indices in data["bootstrap_indices"]]
-
     def serialize(self, filename: str) -> None:
         """
         Saves the object as a JSON file.
@@ -802,10 +856,8 @@ class BootstrappedModelingInputData:
             "index_name": self.response_df.index.name,
             "model_df": self.model_df.to_dict(orient="split"),
             "n_bootstraps": self.n_bootstraps,
-            "bootstrap_indices": [
-                indices.tolist() for indices in self._bootstrap_indices
-            ],
-            "sample_weights": {k: v.tolist() for k, v in self._sample_weights.items()},
+            "normalize_sample_weights": self.normalize_sample_weights,
+            "random_state": self.random_state,
         }
 
         with open(filename, "w") as f:
@@ -830,15 +882,17 @@ class BootstrappedModelingInputData:
         )
         n_bootstraps = data["n_bootstraps"]
 
-        instance = cls(response_df, model_df, n_bootstraps)
+        normalize_sample_weights = data["normalize_sample_weights"]
 
-        # Restore bootstrap indices and sample weights
-        instance._bootstrap_indices = [
-            np.array(indices) for indices in data["bootstrap_indices"]
-        ]
-        instance._sample_weights = {
-            int(k): np.array(v) for k, v in data["sample_weights"].items()
-        }
+        random_state = data["random_state"]
+
+        instance = cls(
+            response_df,
+            model_df,
+            n_bootstraps,
+            normalize_sample_weights=normalize_sample_weights,
+            random_state=random_state,
+        )
 
         return instance
 

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -375,7 +375,7 @@ class ModelingInputData:
         # Ensure response_df is ordered according to predictors_df
         response_df_ordered = response_df_filtered.loc[predictors_df_filtered.index]
 
-        # raise an error if the indicies of the response and predictors
+        # raise an error if the indices of the response and predictors
         # do not match after filtering
         if not response_df_ordered.index.equals(predictors_df_filtered.index):
             raise ValueError(
@@ -764,7 +764,7 @@ class BootstrappedModelingInputData:
             sample_counts = np.bincount(integer_indices, minlength=len(y_indices))
 
             if self.normalize_sample_weights:
-                # note sample_counts.sum() == len(y_indicies) in this case, but
+                # note sample_counts.sum() == len(y_indices) in this case, but
                 # sample_counts.sum() seems to be more canonical
                 sample_weights[i] = sample_counts / sample_counts.sum()
             else:
@@ -772,14 +772,12 @@ class BootstrappedModelingInputData:
 
         self._sample_weights = sample_weights
 
-    def get_bootstrap_sample(
-        self, i: int
-    ) -> tuple[pd.DataFrame, pd.DataFrame, np.ndarray]:
+    def get_bootstrap_sample(self, i: int) -> tuple[np.ndarray, np.ndarray]:
         """
         Retrieves a bootstrap sample by index.
 
         :param i: Bootstrap sample index.
-        :return: Tuple of (Y_resampled, X_resampled, sample_weights).
+        :return: Tuple of (sample_indices, sample_weights).
         :raises IndexError: If the index exceeds the number of bootstraps.
 
         """
@@ -792,8 +790,7 @@ class BootstrappedModelingInputData:
         sample_weights = self.get_sample_weight(i)
 
         return (
-            self.response_df.loc[sampled_indices],
-            self.model_df.loc[sampled_indices],
+            sampled_indices,
             sample_weights,
         )
 
@@ -901,23 +898,21 @@ class BootstrappedModelingInputData:
         self._current_index = 0
         return self
 
-    def __next__(self) -> tuple[pd.DataFrame, pd.DataFrame, np.ndarray]:
+    def __next__(self) -> tuple[np.ndarray, np.ndarray]:
         """
         Provides the next bootstrap sample for iteration.
 
-        :return: Tuple of (Y_resampled, X_resampled, sample_weights).
+        :return: Tuple of (sample_indices, sample_weights).
         :raises StopIteration: When all bootstrap samples are exhausted.
 
         """
         if self._current_index >= self.n_bootstraps:
             raise StopIteration
 
-        Y_resampled, X_resampled, sample_weights = self.get_bootstrap_sample(
-            self._current_index
-        )
+        sample_indices, sample_weights = self.get_bootstrap_sample(self._current_index)
 
         self._current_index += 1
-        return Y_resampled, X_resampled, sample_weights
+        return sample_indices, sample_weights
 
 
 class BootstrapModelResults:
@@ -1276,7 +1271,6 @@ def bootstrap_stratified_cv_modeling(
         n_jobs=4,
     ),
     ci_percentiles: list[int | float] = [95.0, 99.0],
-    use_sample_weight_in_cv: bool = False,
     **kwargs,
 ) -> BootstrapModelResults:
     """
@@ -1293,8 +1287,6 @@ def bootstrap_stratified_cv_modeling(
     :param estimator: scikit-learn estimator. Must support `.fit()` with `sample_weight`
         and allow setting `.cv`. Default is `LassoCV`.
     :param ci_percentiles: List of confidence intervals (e.g., [95.0, 99.0]).
-    :param use_sample_weight_in_cv: If True, weights from bootstrap resampling are used
-        in model fitting. Defaults to False.
     :params kwargs: Additional keyword arguments. The following are supported:
         - bin_by_binding_only: Default False. If False,
             stratification is based on both binding and perturbation ranks.
@@ -1327,10 +1319,6 @@ def bootstrap_stratified_cv_modeling(
         raise ValueError(
             "ci_percentiles must be a list of integers or floats between 0 and 100."
         )
-
-    if not isinstance(use_sample_weight_in_cv, bool):
-        raise ValueError("use_sample_weight_in_cv must be a boolean.")
-    logger.info(f"Using sample weights in CV: {use_sample_weight_in_cv}")
 
     # validate that the index of the response_df and model_df match
     if not bootstrapped_data.response_df.index.equals(bootstrapped_data.model_df.index):
@@ -1378,9 +1366,7 @@ def bootstrap_stratified_cv_modeling(
 
     # Bootstrap iterations
     logger.info("Starting bootstrap modeling iterations...")
-    for index, (y_resampled, x_resampled, sample_weight) in enumerate(
-        bootstrapped_data
-    ):
+    for index, (_, sample_weight) in enumerate(bootstrapped_data):
         logger.debug("Bootstrap iteration index: %d", index)
 
         # Set the random state for StratifiedKFold to the current index
@@ -1397,47 +1383,29 @@ def bootstrap_stratified_cv_modeling(
             logger.warning("Estimator does not have a random_state attribute.")
             pass
 
-        if use_sample_weight_in_cv:
-            # this should be over the entire data set, since we are using the weights
-            # to perform the sampling
-            logger.info("Performing CV by sample weights")
-            classes = stratification_classification(
-                perturbed_tf_series.loc[bootstrapped_data.response_df.index].squeeze(),
-                bootstrapped_data.response_df.squeeze(),
-                bin_by_binding_only=bin_by_binding_only,
-                bins=bins,
-            )
+        logger.info("Performing CV by sample weights")
+        classes = stratification_classification(
+            perturbed_tf_series.loc[bootstrapped_data.response_df.index].squeeze(),
+            bootstrapped_data.response_df.squeeze(),
+            bin_by_binding_only=bin_by_binding_only,
+            bins=bins,
+        )
 
-            model_i = stratified_cv_modeling(
-                bootstrapped_data.response_df,
-                bootstrapped_data.model_df,
-                classes=classes,
-                estimator=estimator,
-                skf=skf,
-                sample_weight=sample_weight,
-            )
-        else:
-            # this is performed on the resampled data
-            logger.info("Performing CV by index partitioning")
-            classes = stratification_classification(
-                perturbed_tf_series.loc[y_resampled.index].squeeze(),
-                y_resampled.squeeze(),
-                bin_by_binding_only=bin_by_binding_only,
-                bins=bins,
-            )
-
-            model_i = stratified_cv_modeling(
-                y_resampled,
-                x_resampled,
-                classes=classes,
-                estimator=estimator,
-                skf=skf,
-            )
+        model_i = stratified_cv_modeling(
+            bootstrapped_data.response_df,
+            bootstrapped_data.model_df,
+            classes=classes,
+            estimator=estimator,
+            skf=skf,
+            sample_weight=sample_weight,
+        )
 
         alpha_list.append(model_i.alpha_)
         bootstrap_coefs.append(model_i.coef_)
     # Convert bootstrap coefficients to DataFrame
-    bootstrap_coefs_df = pd.DataFrame(bootstrap_coefs, columns=x_resampled.columns)
+    bootstrap_coefs_df = pd.DataFrame(
+        bootstrap_coefs, columns=bootstrapped_data.model_df.columns
+    )
 
     # Compute confidence intervals
     ci_dict = {

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -418,6 +418,7 @@ class ModelingInputData:
             raise ValueError("Formula must be provided for modeling.")
 
         if drop_intercept:
+            logger.info("Dropping intercept from the patsy model matrix")
             formula += " - 1"
 
         predictors_df = self.predictors_df  # Apply top-n feature mask

--- a/tfbpmodeling/lasso_modeling.py
+++ b/tfbpmodeling/lasso_modeling.py
@@ -449,6 +449,10 @@ class ModelingInputData:
                 scaled_values, index=design_matrix.index, columns=design_matrix.columns
             )
 
+        logger.info(
+            f"Design matrix columns: {design_matrix.columns}",
+        )
+
         return design_matrix
 
     @classmethod

--- a/tfbpmodeling/loop_modeling.py
+++ b/tfbpmodeling/loop_modeling.py
@@ -32,7 +32,6 @@ def bootstrap_stratified_cv_loop(
         n_jobs=4,
     ),
     ci_percentile: float = 98.0,  # Final confidence interval
-    use_sample_weight_in_cv: bool = False,
     stabilization_ci_start: float = 50.0,  # Starting CI for stabilization
     output_dir: str = "",
     **kwargs,
@@ -45,7 +44,6 @@ def bootstrap_stratified_cv_loop(
     :param perturbed_tf_series: Series of TF binding values for stratification.
     :param estimator: scikit-learn estimator. Default is LassoCV.
     :param ci_percentile: Final confidence interval for results (e.g., 99.0).
-    :param use_sample_weight_in_cv: Whether to use sample weights in CV.
     :param stabilization_ci_start: Starting confidence interval for stabilization (e.g.,
         50.0).
     :param stabilization_ci_step: Step size for increasing CI during stabilization.
@@ -69,9 +67,7 @@ def bootstrap_stratified_cv_loop(
         bootstrap_coefs = []
         alpha_list = []
 
-        for index, (y_resampled, x_resampled, sample_weight) in enumerate(
-            bootstrapped_data
-        ):
+        for index, (_, sample_weight) in enumerate(bootstrapped_data):
             logger.debug(f"Bootstrap iteration index: {index}")
             # Set the random state for StratifiedKFold to the current index
             skf.random_state = index
@@ -86,45 +82,23 @@ def bootstrap_stratified_cv_loop(
             except AttributeError:
                 logger.warning("Estimator does not have a random_state attribute.")
                 pass
-            # by default, use the sample weights rather than the resampled data directly
-            if kwargs.get("use_sample_weight_in_cv", True):
-                # this should be over the entire data set, since we are
-                # using the weights to perform the sampling
-                logger.info("Performing CV by sample weights")
-                classes = stratification_classification(
-                    perturbed_tf_series.loc[
-                        bootstrapped_data.response_df.index
-                    ].squeeze(),
-                    bootstrapped_data.response_df.squeeze(),
-                    bin_by_binding_only=kwargs.get("bin_by_binding_only", False),
-                    bins=kwargs.get("bins", None),
-                )
 
-                model_i = stratified_cv_modeling(
-                    bootstrapped_data.response_df,
-                    bootstrapped_data.model_df,
-                    classes=classes,
-                    estimator=estimator,
-                    skf=skf,
-                    sample_weight=sample_weight,
-                )
-            else:
-                # this is performed on the resampled data
-                logger.info("Performing CV by index partitioning")
-                classes = stratification_classification(
-                    perturbed_tf_series.loc[y_resampled.index].squeeze(),
-                    y_resampled.squeeze(),
-                    bin_by_binding_only=kwargs.get("bin_by_binding_only", False),
-                    bins=kwargs.get("bins", None),
-                )
+            logger.info("Performing CV by sample weights")
+            classes = stratification_classification(
+                perturbed_tf_series.loc[bootstrapped_data.response_df.index].squeeze(),
+                bootstrapped_data.response_df.squeeze(),
+                bin_by_binding_only=kwargs.get("bin_by_binding_only", False),
+                bins=kwargs.get("bins", None),
+            )
 
-                model_i = stratified_cv_modeling(
-                    y_resampled,
-                    x_resampled,
-                    classes=classes,
-                    estimator=estimator,
-                    skf=skf,
-                )
+            model_i = stratified_cv_modeling(
+                bootstrapped_data.response_df,
+                bootstrapped_data.model_df,
+                classes=classes,
+                estimator=estimator,
+                skf=skf,
+                sample_weight=sample_weight,
+            )
 
             alpha_list.append(model_i.alpha_)
             bootstrap_coefs.append(model_i.coef_)
@@ -182,7 +156,6 @@ def bootstrap_stratified_cv_loop(
         perturbed_tf_series=perturbed_tf_series,
         estimator=estimator,
         ci_percentiles=[ci_percentile],
-        use_sample_weight_in_cv=use_sample_weight_in_cv,
         **kwargs,
     )
 

--- a/tfbpmodeling/loop_modeling.py
+++ b/tfbpmodeling/loop_modeling.py
@@ -83,7 +83,6 @@ def bootstrap_stratified_cv_loop(
                 logger.warning("Estimator does not have a random_state attribute.")
                 pass
 
-            logger.info("Performing CV by sample weights")
             classes = stratification_classification(
                 perturbed_tf_series.loc[bootstrapped_data.response_df.index].squeeze(),
                 bootstrapped_data.response_df.squeeze(),

--- a/tfbpmodeling/tests/conftest.py
+++ b/tfbpmodeling/tests/conftest.py
@@ -39,7 +39,7 @@ def bootstrapped_sample_data(sample_data):
     model_df = input_data.get_modeling_data(formula="TF1 + TF1:TF2 + TF1:TF3 - 1")
 
     return BootstrappedModelingInputData(
-        input_data.response_df, model_df, n_bootstraps=5
+        input_data.response_df, model_df, n_bootstraps=5, random_state=42
     )
 
 
@@ -123,6 +123,7 @@ def bootstrapped_random_sample_data(random_sample_data):
         random_sample_data.response_df,
         random_sample_data.get_modeling_data(formula=formula),
         n_bootstraps=100,
+        random_state=42,
     )
 
 

--- a/tfbpmodeling/tests/test_lasso_modeling.py
+++ b/tfbpmodeling/tests/test_lasso_modeling.py
@@ -241,14 +241,16 @@ def test_from_files(monkeypatch, tmp_path):
     assert instance.predictors_df.shape[0] == 2
 
 
-def test_initialization(sample_data):
+def test_initialization_random_state_none(sample_data):
     """Ensure proper initialization with valid inputs."""
     response_df, predictors_df = sample_data
     input_data = ModelingInputData(response_df, predictors_df, perturbed_tf="TF1")
     model_df = input_data.get_modeling_data(formula="TF1 + TF1:TF2 + TF1:TF3 - 1")
 
     boot_data = BootstrappedModelingInputData(
-        input_data.response_df, model_df, n_bootstraps=5
+        input_data.response_df,
+        model_df,
+        n_bootstraps=5,
     )
 
     assert isinstance(boot_data.response_df, pd.DataFrame)
@@ -257,16 +259,60 @@ def test_initialization(sample_data):
     assert boot_data.response_df.index.equals(boot_data.model_df.index)
 
 
+def test_initialization_random_state(sample_data):
+    """Ensure proper initialization with valid inputs."""
+    response_df, predictors_df = sample_data
+    input_data = ModelingInputData(response_df, predictors_df, perturbed_tf="TF1")
+    model_df = input_data.get_modeling_data(formula="TF1 + TF1:TF2 + TF1:TF3 - 1")
+
+    data1 = BootstrappedModelingInputData(
+        input_data.response_df, model_df, n_bootstraps=5, random_state=42
+    )
+
+    data2 = BootstrappedModelingInputData(
+        input_data.response_df, model_df, n_bootstraps=5, random_state=42
+    )
+
+    # data1 and data2 should have the same bootstrap indicies
+    assert all(
+        np.array_equal(i1, i2)
+        for i1, i2 in zip(data1.bootstrap_indices, data2.bootstrap_indices)
+    )
+
+    # data3 should have different bootstrap indices because of different random_state
+    data3 = BootstrappedModelingInputData(
+        input_data.response_df, model_df, n_bootstraps=5, random_state=100
+    )
+
+    assert not all(
+        np.array_equal(i1, i2)
+        for i1, i2 in zip(data3.bootstrap_indices, data2.bootstrap_indices)
+    )
+
+
 def test_invalid_inputs():
     """Ensure errors are raised for invalid inputs."""
+
+    # Require that response_df and model_df are DataFrames
     with pytest.raises(TypeError):
         BootstrappedModelingInputData("not a df", pd.DataFrame(), 5)
 
     with pytest.raises(TypeError):
-        BootstrappedModelingInputData(pd.DataFrame(), "not a df", 5)
+        BootstrappedModelingInputData(
+            pd.DataFrame(index=["a", "b", "c"]), "not a df", 5
+        )
 
-    with pytest.raises(ValueError):
-        BootstrappedModelingInputData(pd.DataFrame(), pd.DataFrame(), -1)
+    # require that the response_df and model_df have the same index in the same order
+    with pytest.raises(IndexError):
+        BootstrappedModelingInputData(
+            pd.DataFrame(index=["a", "b", "c"]), pd.DataFrame(index=["a", "c", "b"]), 5
+        )
+
+    # require that n_bootstraps is a positive integer
+    with pytest.raises(TypeError):
+        BootstrappedModelingInputData(
+            pd.DataFrame(index=["a", "b", "c"]), pd.DataFrame(index=["a", "b", "c"]), -1
+        )
 
 
 def test_bootstrap_sample_shape(bootstrapped_sample_data):
@@ -465,54 +511,6 @@ def test_bootstrapinputmodeldata_serialize_deserialize(
         np.testing.assert_array_equal(
             model_data.sample_weights[key], loaded_data.sample_weights[key]
         )
-
-
-def test_load_bootstrap_indicies(bootstrapped_random_sample_data, tmp_path):
-    """Tests loading of bootstrap indices from a JSON file."""
-    # Create a temporary file for the bootstrap indices
-    json_file = tmp_path / "bootstrap_indices.json"
-
-    # Save the bootstrap indices to the JSON file
-    bootstrapped_random_sample_data.save_indices(json_file)
-
-    # Load the bootstrap indices from the JSON file
-    loaded_indices = BootstrappedModelingInputData.load_indices(json_file)
-
-    # Check that the loaded indices match the original
-    assert len(bootstrapped_random_sample_data.bootstrap_indices) == len(loaded_indices)
-    for orig, loaded in zip(
-        bootstrapped_random_sample_data.bootstrap_indices, loaded_indices
-    ):
-        np.testing.assert_array_equal(orig, loaded)
-
-    response_df = bootstrapped_random_sample_data.response_df
-    model_df = bootstrapped_random_sample_data.model_df
-
-    with pytest.raises(ValueError):
-        BootstrappedModelingInputData(
-            response_df=response_df,
-            model_df=model_df,
-            n_bootstraps=len(loaded_indices),
-            bootstrap_indices=loaded_indices,
-        )
-
-    new_bootstrap_obj = BootstrappedModelingInputData(
-        response_df=response_df,
-        model_df=model_df,
-        bootstrap_indices=loaded_indices,
-    )
-
-    # Ensure the new object has the same sample_weights as the original
-    assert len(bootstrapped_random_sample_data.sample_weights) == len(
-        new_bootstrap_obj.sample_weights
-    )
-    assert all(
-        np.array_equal(
-            bootstrapped_random_sample_data.sample_weights[i],
-            new_bootstrap_obj.sample_weights[i],
-        )
-        for i in range(len(bootstrapped_random_sample_data.sample_weights))
-    )
 
 
 # 2. Testing `stratified_cv_r2()`

--- a/tfbpmodeling/tests/test_lasso_modeling.py
+++ b/tfbpmodeling/tests/test_lasso_modeling.py
@@ -273,7 +273,7 @@ def test_initialization_random_state(sample_data):
         input_data.response_df, model_df, n_bootstraps=5, random_state=42
     )
 
-    # data1 and data2 should have the same bootstrap indicies
+    # data1 and data2 should have the same bootstrap indices
     assert all(
         np.array_equal(i1, i2)
         for i1, i2 in zip(data1.bootstrap_indices, data2.bootstrap_indices)
@@ -317,11 +317,13 @@ def test_invalid_inputs():
 
 def test_bootstrap_sample_shape(bootstrapped_sample_data):
     """Ensure bootstrap samples maintain the correct shape."""
-    Y_resampled, X_resampled, _ = bootstrapped_sample_data.get_bootstrap_sample(0)
+    sample_indices, sample_weights = bootstrapped_sample_data.get_bootstrap_sample(0)
 
-    assert isinstance(Y_resampled, pd.DataFrame)
-    assert isinstance(X_resampled, pd.DataFrame)
-    assert Y_resampled.shape[0] == X_resampled.shape[0]  # Same number of rows
+    assert isinstance(sample_indices, np.ndarray)
+    assert isinstance(sample_weights, np.ndarray)
+    assert (
+        len(sample_indices) == bootstrapped_sample_data.response_df.shape[0]
+    )  # Same number of rows
 
 
 def test_bootstrap_deterministic(sample_data):
@@ -340,10 +342,10 @@ def test_bootstrap_deterministic(sample_data):
     )
 
     for i in range(5):
-        Y1, X1, _ = boot_data_1.get_bootstrap_sample(i)
-        Y2, X2, _ = boot_data_2.get_bootstrap_sample(i)
-        assert Y1.equals(Y2)
-        assert X1.equals(X2)
+        sample_indices1, sample_weights1 = boot_data_1.get_bootstrap_sample(i)
+        sample_indices2, sample_weights2 = boot_data_2.get_bootstrap_sample(i)
+        assert all(x == y for x, y in zip(sample_indices1, sample_indices2))
+        assert all(x == y for x, y in zip(sample_weights1, sample_weights2))
 
 
 def test_invalid_bootstrap_index(bootstrapped_sample_data):
@@ -380,10 +382,9 @@ def test_bootstrap_iteration(bootstrapped_sample_data):
     iterator = iter(bootstrapped_sample_data)
 
     for _ in range(bootstrapped_sample_data.n_bootstraps):
-        Y_resampled, X_resampled, weights = next(iterator)
-        assert isinstance(Y_resampled, pd.DataFrame)
-        assert isinstance(X_resampled, pd.DataFrame)
-        assert isinstance(weights, np.ndarray)
+        sample_indices, sample_weights = next(iterator)
+        assert isinstance(sample_indices, np.ndarray)
+        assert isinstance(sample_weights, np.ndarray)
 
     with pytest.raises(StopIteration):
         next(iterator)


### PR DESCRIPTION
- Closes #27
    This fixes the messy method that was previously implemented to make the bootstrap samples reproducible. Instead of saving the indices, it sets the `random_state` on the sklearn `resample` method. Set the `random_state` argument on any of the modeling cmds in `__main__` to reproduce results with the same bootstrap indicies

- Closes #30 
    This removes the option of using the direclty resampled data, rather than the sample weights, in the bootstrap modeling cmds. Using the directly resampled data risks an observation occurring in both test and train partitions