### PR TITLE
Add function to exclude all model variables

### DIFF
--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -22,6 +22,7 @@ from tfbpmodeling.lasso_modeling import (
 )
 from tfbpmodeling.loop_modeling import bootstrap_stratified_cv_loop
 from tfbpmodeling.SigmoidModel import SigmoidModel
+from tfbpmodeling.utils.exclude_predictor_variables import exclude_predictor_variables
 
 logger = logging.getLogger("main")
 
@@ -124,11 +125,9 @@ def linear_perturbation_binding_modeling(args):
     predictor_variables = input_data.predictors_df.columns.drop(input_data.perturbed_tf)
 
     # drop any variables which are in args.exclude_interactor_variables
-    predictor_variables = [
-        var
-        for var in predictor_variables
-        if var not in args.exclude_interactor_variables
-    ]
+    predictor_variables = exclude_predictor_variables(
+        predictor_variables, args.exclude_interactor_variables
+    )
 
     # create a list of interactor terms with the perturbed_tf as the first term
     interaction_terms = [
@@ -468,11 +467,9 @@ def sigmoid_bootstrap_worker(
             return
     else:
         predictor_variables = input_data.predictors_df.columns.drop(args.perturbed_tf)
-        predictor_variables = [
-            var
-            for var in predictor_variables
-            if var not in args.exclude_interactor_variables
-        ]
+        predictor_variables = exclude_predictor_variables(
+            predictor_variables, args.exclude_interactor_variables
+        )
         interaction_terms = [
             f"{args.perturbed_tf}:{var}" for var in predictor_variables
         ]
@@ -836,7 +833,7 @@ def common_modeling_feature_options(parser: argparse._ArgumentGroup) -> None:
         default=[],
         help=(
             "Comma-separated list of variables to exclude from the interactor terms. "
-            "E.g. red_median,green_median"
+            "E.g. red_median,green_median. To exclude all variables, use 'exclude_all'"
         ),
     )
     parser.add_argument(

--- a/tfbpmodeling/__main__.py
+++ b/tfbpmodeling/__main__.py
@@ -126,7 +126,7 @@ def linear_perturbation_binding_modeling(args):
 
     # drop any variables which are in args.exclude_interactor_variables
     predictor_variables = exclude_predictor_variables(
-        predictor_variables, args.exclude_interactor_variables
+        list(predictor_variables), args.exclude_interactor_variables
     )
 
     # create a list of interactor terms with the perturbed_tf as the first term
@@ -468,7 +468,7 @@ def sigmoid_bootstrap_worker(
     else:
         predictor_variables = input_data.predictors_df.columns.drop(args.perturbed_tf)
         predictor_variables = exclude_predictor_variables(
-            predictor_variables, args.exclude_interactor_variables
+            list(predictor_variables), args.exclude_interactor_variables
         )
         interaction_terms = [
             f"{args.perturbed_tf}:{var}" for var in predictor_variables

--- a/tfbpmodeling/tests/test_utils.py
+++ b/tfbpmodeling/tests/test_utils.py
@@ -1,0 +1,38 @@
+import pytest
+
+from tfbpmodeling.utils.exclude_predictor_variables import exclude_predictor_variables
+
+
+@pytest.mark.parametrize(
+    ("predictors", "exclude", "expected"),
+    [
+        # Nothing excluded  ➜ list unchanged
+        (["A", "B", "C"], [], ["A", "B", "C"]),
+        # Specific exclusions ➜ only those removed
+        (["A", "B", "C"], ["B"], ["A", "C"]),
+        # Sentinel term present ➜ everything removed
+        (["A", "B"], ["exclude_all"], []),
+        # Mixed case: sentinel + other names ➜ still empty
+        (["X", "Y"], ["exclude_all", "X"], []),
+    ],
+)
+def test_exclude_predictor_variables_happy_path(predictors, exclude, expected):
+    assert exclude_predictor_variables(predictors, exclude) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_predictors, bad_exclude, bad_term, expected_message",
+    [
+        # Non-list predictors
+        ("not_a_list", [], "exclude_all", "predictor_variables must be a list"),
+        # Non-list exclude list
+        (["A", "B"], "not_a_list", "exclude_all", "exclude_list must be a list"),
+        # Non-string sentinel
+        (["A"], [], 123, "exclude_all_term must be a string"),
+    ],
+)
+def test_exclude_predictor_variables_type_errors(
+    bad_predictors, bad_exclude, bad_term, expected_message
+):
+    with pytest.raises(TypeError, match=expected_message):
+        exclude_predictor_variables(bad_predictors, bad_exclude, bad_term)

--- a/tfbpmodeling/utils/exclude_predictor_variables.py
+++ b/tfbpmodeling/utils/exclude_predictor_variables.py
@@ -1,0 +1,29 @@
+def exclude_predictor_variables(
+    predictor_variables: list,
+    exclude_list: list,
+    exclude_all_term: str = "exclude_all",
+) -> list:
+    """
+    Given a set of predictor variables, return a list of variables that are not in the
+    exclude_list.
+
+    :param predictor_variables: list of predictor variables
+    :param exclude_list: list of variables to exclude
+    :param exclude_all_term: a term that, if present in the exclude_list, will exclude
+        all predictor variables and return an empty list
+    :return: list of predictor variables that are not in the exclude_list
+    :raises TypeError: if predictor_variables or exclude_list is not a list
+    :raises TypeError: if exclude_all_term is not a string
+
+    """
+    if not isinstance(predictor_variables, list):
+        raise TypeError("predictor_variables must be a list")
+    if not isinstance(exclude_list, list):
+        raise TypeError("exclude_list must be a list")
+    if not isinstance(exclude_all_term, str):
+        raise TypeError("exclude_all_term must be a string")
+
+    exclusions: set[str] = set(exclude_list)
+    if exclude_all_term in exclusions:
+        return []
+    return [v for v in predictor_variables if v not in exclusions]


### PR DESCRIPTION
- Closes #32
    This adds a function to exclude all model variables so that args.add_model_variables can be used to pass in a formula, eg pTF + pTF **2 + pTF**3 using `--exclude_perdictor_variables="exclude_all" --squared_pTF --cubic_pTF`