### PR TITLE
Rename exclude_interactor_variables (#88)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,7 @@ jobs:
     strategy:
       matrix:
         # see https://github.com/actions/runner-images
-        os:
-          [
-            ubuntu-22.04,
-            ubuntu-24.04,
-            macos-13,
-            windows-2022,
-          ]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-15, windows-2022]
         python-version: ["3.11"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -83,8 +83,16 @@ This command executes a sequential 4-stage workflow:
 - `--squared_pTF`: Include squared perturbed TF term
 - `--cubic_pTF`: Include cubic perturbed TF term
 - `--ptf_main_effect`: Include perturbed TF main effect
-- `--exclude_interactor_variables`: Exclude variables from interaction terms
-- `--add_model_variables`: Add custom variables to model
+- `--exclude_model_variables`: comma separated list of column names from the input
+  predictor data to exclude from the automatic generation of model variables. Eg,
+  if you add a column "base_expression" to the predictor data, you can exclude it
+  from the automatic generation of interaction terms by including
+  `--exclude_model_variables base_expression`. To add "base_expression" as a model
+  variable, you would include `--add_model_variables base_expression`.
+- `--add_model_variables`: A comma separated list of variables to add to the
+  model. These must be valid methods of specifying model variables from the
+  input predictor data. See
+  [python's patsy formula documentation](https://patsy.readthedocs.io/en/latest/overview.html)
 
 #### Model Parameters
 
@@ -154,8 +162,8 @@ poetry run python -m tfbpmodeling linear_perturbation_binding_modeling \
     --random_state 12345 \
     --row_max \
     --cubic_pTF \
-    --add_model_variables "red_median,green_median" \
-    --exclude_interactor_variables "batch_effect" \
+    --exclude_model_variables "red_median" \
+    --add_model_variables "red_median" \
     --bins "0,5,10,15,np.inf" \
     --normalize_sample_weights \
     --scale_by_std

--- a/docs/cli/linear-perturbation-binding-modeling.md
+++ b/docs/cli/linear-perturbation-binding-modeling.md
@@ -139,10 +139,10 @@ Include perturbed transcription factor main effect in modeling formula.
 - **Default**: False
 - **Description**: Adds the pTF binding value as a direct predictor
 
-#### `--exclude_interactor_variables EXCLUDE_INTERACTOR_VARIABLES`
-Comma-separated list of variables to exclude from interaction terms.
+#### `--exclude_model_variables EXCLUDE_MODEL_VARIABLES`
+Comma-separated list of variables to exclude from automatic formula generation (main effects and interactions); main effects can be added back with `--add_model_variables`.
 - **Format**: `var1,var2,var3` or `exclude_all`
-- **Example**: `--exclude_interactor_variables "red_median,green_median"`
+- **Example**: `--exclude_model_variables "red_median,green_median"`
 
 #### `--add_model_variables ADD_MODEL_VARIABLES`
 Comma-separated list of additional variables for all-data modeling.
@@ -288,8 +288,8 @@ python -m tfbpmodeling linear_perturbation_binding_modeling \
     --squared_pTF \
     --cubic_pTF \
     --ptf_main_effect \
-    --add_model_variables "red_median,green_median" \
-    --exclude_interactor_variables "batch_effect" \
+    --add_model_variables "red_median" \
+    --exclude_model_variables "red_median" \
     --normalize_sample_weights \
     --scale_by_std \
     --bins "0,5,10,15,np.inf"

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -167,12 +167,16 @@ Exclude specific genes or features:
 echo -e "YBR999W\nYCR888X\ncontrol_gene" > blacklist.txt
 
 # Run analysis with exclusions
+# note that we are excluding base_expression from the automatically
+# generated interaction terms in the model formula. However, we are adding
+# it back in as a main effect in the model with --add_model_variables
 python -m tfbpmodeling linear_perturbation_binding_modeling \
     --response_file data/expression.csv \
     --predictors_file data/binding.csv \
     --perturbed_tf YPD1 \
     --blacklist_file blacklist.txt \
-    --exclude_interactor_variables "batch_effect,technical_replicate"
+    --exclude_model_variables "base_expression"
+    --add_model_variables "base_expression"
 ```
 
 ## Example Workflow

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -175,7 +175,7 @@ python -m tfbpmodeling linear_perturbation_binding_modeling \
     --predictors_file data/binding.csv \
     --perturbed_tf YPD1 \
     --blacklist_file blacklist.txt \
-    --exclude_model_variables "base_expression"
+    --exclude_model_variables "base_expression" \
     --add_model_variables "base_expression"
 ```
 

--- a/docs/tutorials/advanced-features.md
+++ b/docs/tutorials/advanced-features.md
@@ -45,7 +45,7 @@ python -m tfbpmodeling linear_perturbation_binding_modeling \
     --predictors_file data/binding.csv \
     --perturbed_tf YPD1 \
     --add_model_variables "batch_id,plate_position,extraction_date" \
-    --exclude_interactor_variables "batch_id,technical_replicate"
+    --exclude_model_variables "batch_id,technical_replicate"
 ```
 
 ### Row-wise Features

--- a/tfbpmodeling/interface.py
+++ b/tfbpmodeling/interface.py
@@ -98,9 +98,9 @@ def linear_perturbation_binding_modeling(args):
     # extract a list of predictor variables, which are the columns of the predictors_df
     predictor_variables = input_data.predictors_df.columns.drop(input_data.perturbed_tf)
 
-    # drop any variables which are in args.exclude_interactor_variables
+    # drop any variables which are in args.exclude_model_variables
     predictor_variables = exclude_predictor_variables(
-        list(predictor_variables), args.exclude_interactor_variables
+        list(predictor_variables), args.exclude_model_variables
     )
 
     # create a list of interactor terms with the perturbed_tf as the first term
@@ -553,12 +553,16 @@ def common_modeling_feature_options(parser: argparse._ArgumentGroup) -> None:
         ),
     )
     parser.add_argument(
-        "--exclude_interactor_variables",
+        "--exclude_model_variables",
         type=parse_comma_separated_list,
         default=[],
         help=(
-            "Comma-separated list of variables to exclude from the interactor terms. "
-            "E.g. red_median,green_median. To exclude all variables, use 'exclude_all'"
+            "Comma-separated list of variables to exclude from the automatic "
+            "formula generation. E.g. red_median,green_median. "
+            "To exclude all variables, use 'exclude_all'. If you want to exclude a "
+            "variable from the interaction terms, but include it as a main effect, "
+            "you can exclude it with this flag and then add it back in with "
+            "--add_model_variables"
         ),
     )
     parser.add_argument(

--- a/tfbpmodeling/tests/test_interface.py
+++ b/tfbpmodeling/tests/test_interface.py
@@ -126,7 +126,7 @@ def make_args(tmp_path):
         row_max=False,
         squared_pTF=False,
         cubic_pTF=False,
-        exclude_interactor_variables=[],
+        exclude_model_variables=[],
         add_model_variables=[],
         ptf_main_effect=False,
         # CI & iteration


### PR DESCRIPTION
This primarily focuses on improving the name of the exclude model variables and add model variables cmd line options